### PR TITLE
PCC-457 Fixed git command to retrieve latest tag

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -91770,7 +91770,7 @@ exports.getJiraCodeFromString = exports.getJiraIssueCodesFromCommits = exports.g
 function getLatestTag(tools) {
     return __awaiter(this, void 0, void 0, function* () {
         let latestTag = '';
-        yield tools.exec('git describe --tags --abbrev=0', [], {
+        yield tools.exec('git tag --list \'v[0-9]*.[0-9]*.[0-9]*\' --sort v:refname | tail -1', [], {
             silent: false,
             listeners: {
                 stdout: (buffer) => {

--- a/src/utils/git.util.ts
+++ b/src/utils/git.util.ts
@@ -3,7 +3,7 @@ import { Toolkit } from "actions-toolkit";
 export async function getLatestTag(tools: Toolkit): Promise<string> {
     let latestTag = '';
 
-    await tools.exec('git describe --tags --abbrev=0', [], { //git tag --list --sort v:refname --merged | tail -1
+    await tools.exec('git tag --list \'v[0-9]*.[0-9]*.[0-9]*\' --sort v:refname | tail -1', [], { //git tag --list --sort v:refname --merged | tail -1
         silent: false,
         listeners: {
             stdout: (buffer) => {


### PR DESCRIPTION
## Description

This PR fixes the bug where not always the latest tag version is retrieved

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📕 storybook
- [x] 🙅 no documentation needed
